### PR TITLE
Add 'action' package for the stoiridhtools.logging module

### DIFF
--- a/doc/source/library/logging/action.rst
+++ b/doc/source/library/logging/action.rst
@@ -1,0 +1,104 @@
+:py:mod:`stoiridhtools.logging.action` --- Organise log event messages under the form of tasks
+====================================================================================================
+
+.. Copyright 2015-2016 Stòiridh Project.
+.. This file is under the FDL licence, see LICENCE.FDL for details.
+
+.. sectionauthor:: William McKIE <mckie.william@hotmail.co.uk>
+
+.. py:module:: stoiridhtools.logging.action
+   :synopsis: Organise log event messages under the form of tasks
+
+----------------------------------------------------------------------------------------------------
+
+Introduction
+------------
+
+The :py:mod:`stoiridhtools.logging.action` module organises log event messages for a logger under
+the form of tasks in order to provide feedbacks about the current progression to the user.
+
+Example::
+
+   import stoiridhtools.logging
+   import stoiridhtools.logging.action
+
+   LOG = stoiridhtools.logging.get_logger(__name__)
+
+
+   def run():
+      action = stoiridhtools.logging.action.create(logger=LOG)
+      action.begin('Starting a new task')
+      action.step('Step #1')
+
+      # ...
+
+      action.step('Step #2')
+
+      # ...
+
+      action.end()
+
+Output::
+
+      >>> run()
+      :: Starting a new task
+          Step #1
+          Step #2
+
+Functions
+---------
+
+.. py:function:: create(**kwargs)
+
+   Create a new action for a :py:ref:`logger <stoiridhtools.logging.logger>`. If no keyword
+   arguments are given, then the root logger will be use as default logger. Currently, this
+   function only supports the following keyword arguments:
+
+   +-----------+----------------------------------------------------------------------------------+
+   | Arguments | Description                                                                      |
+   +===========+==================================================================================+
+   | name      | Logger's name.                                                                   |
+   +-----------+----------------------------------------------------------------------------------+
+   | logger    | Logger's instance.                                                               |
+   +-----------+----------------------------------------------------------------------------------+
+
+   .. note::
+
+      For the ``logger`` keyword argument, if it is not an instance of
+      :py:class:`~stoiridhtools.logging.Logger`, then the root logger is returned.
+
+   :raise ValueError: if both ``name`` and ``logger`` are specified at the same time.
+
+LoggerAction Object
+-------------------
+
+.. py:class:: LoggerAction(**kwargs)
+
+   The :py:class:`LoggerAction` class organises log event messages under the form of tasks.
+
+   .. note::
+
+      This class should not be instancied directly. Prefer to use the :py:func:`create` function
+      which is more appropriate.
+
+   :raise ValueError: if both ``name`` and ``logger`` are specified at the same time.
+
+   .. py:attribute:: logger
+
+      Return the logger associated to the action.
+
+   .. py:method:: begin(msg, *args, **kwargs)
+
+      Notify the user of the beginning of a new task.
+
+   .. py:method:: step(msg, *args, **kwargs)
+
+      Notify the user of the action progress.
+
+   .. py:method:: end()
+
+      End the task previously begun.
+
+      .. note::
+
+         Currently, this method do nothing but is reserved for a future use.

--- a/doc/source/library/logging/index.rst
+++ b/doc/source/library/logging/index.rst
@@ -15,3 +15,4 @@ provided by |project|.
    :maxdepth: 1
 
    logging
+   action

--- a/doc/source/library/logging/logging.rst
+++ b/doc/source/library/logging/logging.rst
@@ -167,6 +167,8 @@ Functions
 
    Log and print out a message with severity level `WARNING`.
 
+.. _stoiridhtools.logging.logger:
+
 Logger Object
 -------------
 

--- a/stoiridhtools/logging/__init__.py
+++ b/stoiridhtools/logging/__init__.py
@@ -244,6 +244,9 @@ class Logger:
         self._root_proxy = kwargs.pop('root_proxy', None)
         self.level = level
 
+        if self._root_proxy is not None and name not in self._root_proxy.loggers:
+            self._root_proxy.loggers[name] = self
+
     @property
     def name(self):
         """Return the logger's name."""
@@ -299,6 +302,9 @@ class Logger:
         """Log and print out a message with severity level `WARNING`."""
         self._logger.warning(msg, *args, **kwargs)
 
+    def __repr__(self):
+        return '<%s name=%s level=%s>' % (self.__class__.__name__, self.name, self.level)
+
 
 class _LoggingProxy:
     DEFAULT_FILENAME = 'stoiridhtools-%(date)s.log' % {'date': date.today()}
@@ -307,6 +313,7 @@ class _LoggingProxy:
         self._root_logger = Logger(level=NOTSET)
         self._handlers = _LoggingHandlers(stream=logging.StreamHandler())
         self._handlers.attach(self._root_logger)
+        self._loggers = dict()
 
     @property
     def root(self):
@@ -326,6 +333,11 @@ class _LoggingProxy:
             value = sys.stderr
 
         self._handlers.stream = value
+
+    @property
+    def loggers(self):
+        """Return the loggers bound to the proxy."""
+        return self._loggers
 
     def init(self, **kwargs):
         """Initialise the logging proxy. Currently, this function only supports the following
@@ -492,7 +504,7 @@ def get_logger(name=None):
 
     .. seealso:: :py:func:`logging.getLogger`
     """
-    return Logger(name, root_proxy=_PROXY)
+    return _PROXY.loggers.get(name, Logger(name, root_proxy=_PROXY))
 
 
 def get_level():

--- a/stoiridhtools/logging/__init__.py
+++ b/stoiridhtools/logging/__init__.py
@@ -359,6 +359,8 @@ class _LoggingProxy:
         else:
             self.stream.stream = stream
 
+        self._handlers.attach_stream_to_logger(self._root_logger)
+
         if 'filename' in kwargs and 'path' in kwargs:
             raise ValueError('both argument (filename) and argument (path) should not be specified '
                              'together')

--- a/stoiridhtools/logging/action.py
+++ b/stoiridhtools/logging/action.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+####################################################################################################
+##                                                                                                ##
+##            Copyright (C) 2016 William McKIE                                                    ##
+##                                                                                                ##
+##            This program is free software: you can redistribute it and/or modify                ##
+##            it under the terms of the GNU General Public License as published by                ##
+##            the Free Software Foundation, either version 3 of the License, or                   ##
+##            (at your option) any later version.                                                 ##
+##                                                                                                ##
+##            This program is distributed in the hope that it will be useful,                     ##
+##            but WITHOUT ANY WARRANTY; without even the implied warranty of                      ##
+##            MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                       ##
+##            GNU General Public License for more details.                                        ##
+##                                                                                                ##
+##            You should have received a copy of the GNU General Public License                   ##
+##            along with this program.  If not, see <http://www.gnu.org/licenses/>.               ##
+##                                                                                                ##
+####################################################################################################
+"""
+The :py:mod:`stoiridhtools.logging.action` module organises log event messages for a logger under
+the form of tasks in order to provide feedbacks about the current progression to the user.
+
+Example::
+
+   import stoiridhtools.logging
+   import stoiridhtools.logging.action
+
+   LOG = stoiridhtools.logging.get_logger(__name__)
+
+
+   def run():
+      action = stoiridhtools.logging.action.create(logger=LOG)
+      action.begin('Starting new task')
+      action.step('Step #1')
+
+      # ...
+
+      action.step('Step #2')
+
+      # ...
+
+      action.end()
+
+Output::
+
+      >>> run()
+      :: Starting a new task
+          Step #1
+          Step #2
+"""
+import colorama
+
+import stoiridhtools.logging
+
+__all__ = ['create', 'LoggerAction']
+
+
+class LoggerAction:
+    """The :py:class:`LoggerAction` class organises log event messages under the form of tasks.
+
+    .. note::
+
+       This class should not be instancied directly. Prefer to use the :py:func:`create` function
+       which is more appropriate.
+    """
+    PREFIX = colorama.Style.BRIGHT + colorama.Fore.MAGENTA + ':: ' + colorama.Fore.RESET
+
+    def __init__(self, **kwargs):
+        if 'name' in kwargs and 'logger' in kwargs:
+            raise ValueError('both argument (name) and argument (logger) should not be specified '
+                             'together')
+
+        if 'name' in kwargs:
+            self._logger = stoiridhtools.logging.get_logger(kwargs.get('name', None))
+        elif 'logger' in kwargs:
+            logger = kwargs.pop('logger', None)
+            if logger is not None and isinstance(logger, stoiridhtools.logging.Logger):
+                self._logger = logger
+            else:
+                self._logger = stoiridhtools.logging.get_logger()
+        else:
+            self._logger = stoiridhtools.logging.get_logger()
+
+        self._indent = 4
+
+    @property
+    def logger(self):
+        """Return the logger associated to the action."""
+        return self._logger
+
+    def begin(self, msg, *args, **kwargs):
+        """Notify the user of the beginning of a new task."""
+        self._logger.message(self.PREFIX + msg, *args, **kwargs)
+
+    def step(self, msg, *args, **kwargs):
+        """Notify the user of the action progress."""
+        self._logger.message((' ' * self._indent) + msg, *args, **kwargs)
+
+    def end(self):
+        """End the task previously begun.
+
+        .. note::
+
+           Currently, this method do nothing but is reserved for a future use.
+        """
+        pass
+
+
+def create(**kwargs):
+    """Create a new action for a :py:ref:`logger <stoiridhtools.logging.logger>`. If no keyword
+    arguments are given, then the root logger will be use as default logger. Currently, this
+    function only supports the following keyword arguments:
+
+    +-----------+----------------------------------------------------------------------------------+
+    | Arguments | Description                                                                      |
+    +===========+==================================================================================+
+    | name      | Logger's name.                                                                   |
+    +-----------+----------------------------------------------------------------------------------+
+    | logger    | Logger's instance.                                                               |
+    +-----------+----------------------------------------------------------------------------------+
+
+    .. note::
+
+       For the ``logger`` keyword argument, if it is not an instance of
+       :py:class:`~stoiridhtools.logging.Logger`, then the root logger is returned.
+
+    :raise ValueError: if both ``name`` and ``logger`` are specified at the same time.
+    """
+    try:
+        return LoggerAction(**kwargs)
+    except ValueError:
+        raise

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -19,8 +19,8 @@
 ####################################################################################################
 import io
 import os
-import unittest
 import shutil
+import unittest
 from pathlib import Path
 
 import colorama
@@ -86,13 +86,20 @@ class TestLogging(unittest.TestCase):
         stoiridhtools.logging.init(filename=str(filename), stream=self.stderr)
 
     def test_logger(self):
+        root_logger = stoiridhtools.logging.get_logger()
         logger = stoiridhtools.logging.get_logger()
+
+        self.assertEqual(logger, root_logger)
         self.assertEqual('root', logger.name)
 
+        logging_logger = stoiridhtools.logging.get_logger(__name__)
         logger = stoiridhtools.logging.get_logger(__name__)
+
+        self.assertEqual(logger, logging_logger)
         self.assertEqual(__name__, logger.name)
 
         logger = self.LOG
+        self.assertEqual(logger, logging_logger)
         self.assertEqual(__name__, logger.name)
 
     def test_level(self):
@@ -245,3 +252,7 @@ class TestLogging(unittest.TestCase):
             self.LOG.warning('Logging a message from test_logging with a severity level: %s',
                              'warning')
             self.assertEqual(result % __name__, wrapper.get_lines())
+
+    def test_bf_repr(self):
+        result = '<Logger name=%s level=%d>' % (self.LOG.name, self.LOG.level)
+        self.assertEqual(result, repr(self.LOG))

--- a/tests/test_logging_action.py
+++ b/tests/test_logging_action.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+####################################################################################################
+##                                                                                                ##
+##            Copyright (C) 2016 William McKIE                                                    ##
+##                                                                                                ##
+##            This program is free software: you can redistribute it and/or modify                ##
+##            it under the terms of the GNU General Public License as published by                ##
+##            the Free Software Foundation, either version 3 of the License, or                   ##
+##            (at your option) any later version.                                                 ##
+##                                                                                                ##
+##            This program is distributed in the hope that it will be useful,                     ##
+##            but WITHOUT ANY WARRANTY; without even the implied warranty of                      ##
+##            MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                       ##
+##            GNU General Public License for more details.                                        ##
+##                                                                                                ##
+##            You should have received a copy of the GNU General Public License                   ##
+##            along with this program.  If not, see <http://www.gnu.org/licenses/>.               ##
+##                                                                                                ##
+####################################################################################################
+import io
+import os
+import shutil
+import unittest
+from pathlib import Path
+
+import stoiridhtools
+import stoiridhtools.logging
+import stoiridhtools.logging.action
+
+import util.io
+
+
+class TestLoggingAction(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # use a custom error stream in order to be able to intercept the logging messages from
+        # stoiridhtools.logging
+        cls.stderr = io.StringIO()
+
+        cls.test_dir = Path(os.environ['HOME'], '.config', 'StoiridhProject-Test')
+        cls.filename = cls.test_dir.joinpath('StoiridhTools', 'logs', 'stoiridhtools.log')
+        cls.filename.parent.mkdir(parents=True)
+
+        stoiridhtools.init()
+
+        cls.LOG = stoiridhtools.logging.get_logger(__name__)
+        cls.ACTION = stoiridhtools.logging.action.create(logger=cls.LOG)
+
+    @classmethod
+    def tearDownClass(cls):
+        stoiridhtools.deinit()
+
+        if cls.test_dir.exists():
+            shutil.rmtree(str(cls.test_dir))
+
+    def setUp(self):
+        stoiridhtools.logging.init(filename=self.filename, stream=self.stderr)
+
+    def test_create(self):
+        root_logger = stoiridhtools.logging.get_logger()
+
+        action = stoiridhtools.logging.action.create()
+        self.assertIsNotNone(action)
+        self.assertEqual(root_logger, action.logger)
+
+        action = stoiridhtools.logging.action.create(name=__name__)
+        self.assertIsNotNone(action)
+        self.assertEqual(self.LOG, action.logger)
+
+        action = stoiridhtools.logging.action.create(logger=self.LOG)
+        self.assertIsNotNone(action)
+        self.assertEqual(self.LOG, action.logger)
+
+        with self.assertRaises(ValueError):
+            action = stoiridhtools.logging.action.create(name=__name__, logger=self.LOG)
+
+        class DummyLogger:
+            def error(self):
+                pass
+
+            def warning(self):
+                pass
+
+        action = stoiridhtools.logging.action.create(logger=DummyLogger())
+        self.assertIsNotNone(action)
+        self.assertEqual(root_logger, action.logger)
+
+    def test_begin_end(self):
+        result = self.ACTION.PREFIX + 'Starting a new Task'
+
+        with util.io.OutputStreamWrapper(err_stream=self.stderr) as wrapper:
+            self.ACTION.begin('Starting a new Task')
+            self.assertEqual(result, wrapper.get_lines())
+            self.ACTION.end()
+
+    def test_step(self):
+        with util.io.OutputStreamWrapper(err_stream=self.stderr) as wrapper:
+            self.ACTION.begin('Starting a new Task')
+            wrapper.clear()
+
+            self.ACTION.step('Subtask 01')
+            self.assertEqual('    Subtask 01', wrapper.get_lines())
+            self.ACTION.step('Subtask 02')
+            self.assertEqual('    Subtask 02', wrapper.get_lines())
+
+            self.ACTION.end()

--- a/tests/util/io.py
+++ b/tests/util/io.py
@@ -31,6 +31,15 @@ class OutputStreamWrapper:
         self.stdout = out_stream
         self.stderr = err_stream
 
+    def clear(self):
+        if self.stdout is not None:
+            self.stdout.seek(0)
+            self.stdout.truncate()
+
+        if self.stderr is not None:
+            self.stderr.seek(0)
+            self.stderr.truncate()
+
     def get_lines(self, stream=None):
         """Return the latest lines written from the :py:data:`sys.stdout` stream and/or the
         :py:data:`sys.stderr` stream. If `stream` is specified, then the method will return the


### PR DESCRIPTION
This package is intended to replace v*print functions (#41). When a task begins we can use the methods provided by the package in order to provide feedbacks to the user by organising the output of our task.

Task-number: #38