### PR TITLE
Replace Sphinx roles for Python standard types

### DIFF
--- a/doc/source/library/config.rst
+++ b/doc/source/library/config.rst
@@ -89,7 +89,7 @@ Objects
 
    .. py:method:: read(section)
 
-      Read the data associated to *section* and return them under the form of a :py:obj:`dict`.
+      Read the data associated to *section* and return them under the form of a :py:class:`dict`.
 
       If there is no section called *section* within the configuration file, then a :py:obj:`None`
       type is returned.

--- a/doc/source/library/sdk.rst
+++ b/doc/source/library/sdk.rst
@@ -27,7 +27,7 @@ Objects
 
    Parameters:
 
-   - *versions*, corresponds to a :py:obj:`list` of versions string.
+   - *versions*, corresponds to a :py:class:`list` of versions string.
    - *path*, is the root path where the packages will be installed. If no path is given, the
      default path from the :py:meth:`~stoiridhtools.Config.get_default_path` will be used.
    - *loop*, is an optional parameter that refers to an asynchronous event loop. If :py:obj:`None`,

--- a/doc/source/library/versionnumber.rst
+++ b/doc/source/library/versionnumber.rst
@@ -25,7 +25,7 @@ Objects
               VersionNumber(major, minor, patch)
 
    Construct a :py:class:`VersionNumber` object. *args* corresponds to the major, minor, and patch
-   segments and accepts either a :py:obj:`str` object or an :py:obj:`int` object.
+   segments and accepts either a :py:class:`str` object or an :py:class:`int` object.
 
    Example::
 
@@ -36,7 +36,7 @@ Objects
       >>> VersionNumber(1, 5, 7)
       1.5.7
 
-   :raise: :py:exc:`ValueError` if :py:obj:`str` is not a valid version like
+   :raise: :py:exc:`ValueError` if :py:class:`str` is not a valid version like
            ``major.minor[.patch]``.
 
    .. py:attribute:: major

--- a/stoiridhtools/config.py
+++ b/stoiridhtools/config.py
@@ -141,7 +141,7 @@ class Config:
 
     async def read(self, section):
         """Return the data associated to *section* and return them under the form of a
-        :py:obj:`dict`.
+        :py:class:`dict`.
 
         If there is no section called *section* within the configuration file, then a :py:obj:`None`
         type is returned.

--- a/stoiridhtools/sdk.py
+++ b/stoiridhtools/sdk.py
@@ -41,7 +41,7 @@ class SDK:
 
     Parameters:
 
-    - *versions*, corresponds to a :py:obj:`list` of versions string.
+    - *versions*, corresponds to a :py:class:`list` of versions string.
     - *path*, is the root path where the packages will be installed. If no path is given, the
       default path from the :py:meth:`~stoiridhtools.Config.get_default_path` will be used.
     - *loop*, is an optional parameter that refers to an asynchronous event loop. If

--- a/stoiridhtools/versionnumber.py
+++ b/stoiridhtools/versionnumber.py
@@ -26,7 +26,7 @@ import re
 
 class VersionNumber:
     """Construct a :py:class:`VersionNumber` object. *args* corresponds to the major, minor, and
-    patch segments and accepts either a :py:obj:`str` object or an :py:obj:`int` object.
+    patch segments and accepts either a :py:class:`str` object or an :py:class:`int` object.
 
     Example::
 
@@ -37,7 +37,7 @@ class VersionNumber:
         >>> VersionNumber(1, 5, 7)
         1.5.7
 
-    :raise: :py:exc:`ValueError` if :py:obj:`str` is not a valid version like
+    :raise: :py:exc:`ValueError` if :py:class:`str` is not a valid version like
             ``major.minor[.patch]``.
     """
     version_re = re.compile(r'^(\d+)\.(\d+)(?:\.(\d+))?$')


### PR DESCRIPTION
In the documentation, there are Python standard types which use the
:py:obj: role but it would be better to use the :py:class: role
which is more appropriate since the standard types like str and int
are classes.

Task-number: #42