### PR TITLE
Replace the logging module by the stoiridhtools.logging module

### DIFF
--- a/stoiridhtools/qbs/profile.py
+++ b/stoiridhtools/qbs/profile.py
@@ -22,15 +22,16 @@ The :py:mod:`stoiridhtools.qbs.profile` module allows to retrieve the Qbs profil
 configuration file.
 """
 import configparser
-import logging
 import re
 import sys
 from pathlib import Path
 
+import stoiridhtools.logging
+
 __all__ = ['Profile', 'read_config']
 
 
-LOG = logging.getLogger(__name__)
+LOG = stoiridhtools.logging.get_logger(__name__)
 KEY = 'qt-project\\qbs\\'
 SECTION = 'org'
 INT_RE = re.compile(r'^(\d+)$')  # used by the _make_value(value) function

--- a/stoiridhtools/qbs/scanner.py
+++ b/stoiridhtools/qbs/scanner.py
@@ -22,18 +22,18 @@ The :py:mod:`stoiridhtools.qbs.scanner` module provides a :py:class:`Scanner` cl
 scan on specific environment variables in order to find the wanted version of Qbs.
 """
 import asyncio
-import logging
 import os
 import re
 import subprocess
 import sys
 from pathlib import Path
 
+import stoiridhtools.logging
 from stoiridhtools.qbs import Qbs
 from stoiridhtools.versionnumber import VersionNumber
 
 # logging
-LOG = logging.getLogger(__name__)
+LOG = stoiridhtools.logging.get_logger(__name__)
 
 
 class Scanner:

--- a/stoiridhtools/sdk.py
+++ b/stoiridhtools/sdk.py
@@ -22,7 +22,6 @@ The :py:mod:`stoiridhtools.sdk` module provides a :py:class:`SDK` class that han
 well as the remove of the Qbs packages.
 """
 import asyncio
-import logging
 import shutil
 import tarfile
 import tempfile
@@ -30,10 +29,11 @@ import urllib.request
 from itertools import filterfalse
 from pathlib import Path
 
+import stoiridhtools.logging
 from stoiridhtools.versionnumber import VersionNumber
 
 # logging
-LOG = logging.getLogger(__name__)
+LOG = stoiridhtools.logging.get_logger(__name__)
 
 
 class SDK:


### PR DESCRIPTION
Some part of the code still used the `logging` module instead of the `stoiridhtools.logging` module.

Task-number: #49