### PR TITLE
Replace v*print by logging actions

### DIFF
--- a/doc/source/library/stoiridhtools.rst
+++ b/doc/source/library/stoiridhtools.rst
@@ -1,4 +1,4 @@
-:py:mod:`stoiridhtools` --- Control verbosity between submodules
+:py:mod:`stoiridhtools` --- Initialise and deinitialise |project|
 ====================================================================================================
 
 .. Copyright 2015-2016 Stòiridh Project.
@@ -8,33 +8,23 @@
 .. sectionauthor:: William McKIE <mckie.william@hotmail.co.uk>
 
 .. py:module:: stoiridhtools
-   :synopsis: Control verbosity between submodules
+   :synopsis: Initialise and deinitialise |project|.
 
 ----------------------------------------------------------------------------------------------------
 
 Introduction
 ------------
 
-The :py:mod:`stoiridhtools` module provides some utility functions in order to control the verbosity
-between submodules.
+The :py:mod:`stoiridhtools` module is the main entry-point of |project|. This module offers two
+functions that should not be directly called from other modules.
 
 Functions
 ---------
 
-.. py:function:: enable_verbosity(enable)
+.. py:function:: init()
 
-   Enable or disable the verbosity of the messages.
+   Initialise |project|.
 
-.. py:function:: vprint(message)
+.. py:function:: deinit()
 
-   Print a verbose message in the :py:data:`sys.stdout`, if and only if the
-   :py:func:`enable_verbosity` is enabled.
-
-.. py:function:: vsprint(message)
-
-   Print a verbose step message in the :py:data:`sys.stdout`, if and only if the
-   :py:func:`enable_verbosity` is enabled.
-
-   .. note::
-
-      A step message starts with a ``::`` character.
+   Deinitialise |project|.

--- a/stoiridhtools/__init__.py
+++ b/stoiridhtools/__init__.py
@@ -18,8 +18,8 @@
 ##                                                                                                ##
 ####################################################################################################
 """
-The :py:mod:`stoiridhtools` module provides some utility functions in order to control the verbosity
-between submodules.
+The :py:mod:`stoiridhtools` module is the main entry-point of Stòiridh Tools. This module offers two
+functions that should not be directly called from other modules.
 """
 import sys
 from pathlib import Path
@@ -29,7 +29,7 @@ import colorama
 import stoiridhtools.logging
 
 __version__ = '0.1.0'
-__all__ = ['__version__', 'enable_verbosity', 'vprint', 'vsprint']
+__all__ = ['__version__']
 
 
 # constants
@@ -93,32 +93,3 @@ def get_default_path():
             path = Path(root_path, organisation, application_name)
 
     return path
-
-
-# private class
-class _Verbosity:
-    enable = False
-
-
-def enable_verbosity(enable):
-    """Enable or disable the verbosity of the messages."""
-    _Verbosity.enable = enable
-
-
-def vprint(message):
-    """Print a verbose message in the :py:data:`sys.stdout`, if and only if the
-    :py:func:`enable_verbosity` is enabled."""
-    if _Verbosity.enable:
-        print(message)
-
-
-def vsprint(message):
-    """Print a verbose step message in the :py:data:`sys.stdout`, if and only if the
-    :py:func:`enable_verbosity` is enabled.
-
-    .. note::
-
-        A step message starts with a '::' character.
-    """
-    if _Verbosity.enable:
-        print('::', message)

--- a/stoiridhtools/cli/__init__.py
+++ b/stoiridhtools/cli/__init__.py
@@ -21,7 +21,7 @@ import argparse
 import asyncio
 
 import stoiridhtools.logging
-from stoiridhtools import PROJECT_NAME, __version__, enable_verbosity
+from stoiridhtools import PROJECT_NAME, __version__
 
 LOG = stoiridhtools.logging.get_logger(__name__)
 
@@ -206,7 +206,9 @@ class CommandManager:
         args, unknown_args = self._parser.parse_known_args()
 
         if hasattr(args, 'verbose'):
-            enable_verbosity(args.verbose)
+            stoiridhtools.logging.set_level(stoiridhtools.logging.WARNING)
+        else:
+            stoiridhtools.logging.set_level(stoiridhtools.logging.CRITICAL)
 
         if args.version:
             print(__version__)

--- a/tests/test_stoiridhtools.py
+++ b/tests/test_stoiridhtools.py
@@ -17,56 +17,18 @@
 ##            along with this program.  If not, see <http://www.gnu.org/licenses/>.               ##
 ##                                                                                                ##
 ####################################################################################################
-import io
-import sys
 import unittest
 
 import stoiridhtools
 
 
-class StreamMorph:
-    def __init__(self):
-        sys.stdout = io.StringIO()
-        self.seek = 0
-
-    def get_line(self):
-        output = sys.stdout.getvalue()
-        result = output[self.seek:len(output) - 1]
-        if result is not None:
-            self.seek += len(output)
-        return result or None
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        if exc_type is None:
-            sys.stdout.close()
-            sys.stdout = sys.__stdout__
-        else:
-            return False
-
-
 class TestStoiridhTools(unittest.TestCase):
-    def setUp(self):
-        stoiridhtools.enable_verbosity(False)
+    @classmethod
+    def tearDownClass(cls):
+        stoiridhtools.deinit()
 
-    def test_verbosity_on(self):
-        with StreamMorph() as morph:
-            stoiridhtools.enable_verbosity(True)
+    def test_init(self):
+        stoiridhtools.init()
 
-            stoiridhtools.vprint("Testing the vprint function")
-            self.assertEqual("Testing the vprint function", morph.get_line())
-
-            stoiridhtools.vsprint("Step1: Testing vsprint function")
-            self.assertEqual(":: Step1: Testing vsprint function", morph.get_line())
-
-    def test_verbosity_off(self):
-        with StreamMorph() as morph:
-            stoiridhtools.enable_verbosity(False)
-
-            stoiridhtools.vprint("Testing vprint function")
-            self.assertIsNone(morph.get_line())
-
-            stoiridhtools.vsprint("Step1: Testing vsprint function")
-            self.assertIsNone(morph.get_line())
+    def test_deinit(self):
+        stoiridhtools.deinit()


### PR DESCRIPTION
Since the introduction of the stoiridhtools.logging.action API, v*print were obsoletes and must be replaced by logging actions.

Task-number: #41