### PR TITLE
Deny the execution of Stòiridh Tools on unsupported platforms

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,11 @@ from setuptools import find_packages, setup
 import stoiridhtools
 
 if sys.version_info < (3, 5):
-    print('ERROR: StoiridhTools requires at least Python 3.5 to run.')
+    print('ERROR: Stòiridh Tools requires at least Python 3.5 to run.')
+    sys.exit(1)
+
+if not (sys.platform.startswith('linux') or sys.platform.startswith('win32')):
+    print('ERROR: Stòiridh Tools is only available on GNU/Linux or Windows.')
     sys.exit(1)
 
 

--- a/stoiridhtools/__init__.py
+++ b/stoiridhtools/__init__.py
@@ -21,6 +21,7 @@
 The :py:mod:`stoiridhtools` module is the main entry-point of Stòiridh Tools. This module offers two
 functions that should not be directly called from other modules.
 """
+import os
 import sys
 from pathlib import Path
 
@@ -62,6 +63,14 @@ def deinit():
 
 def main():
     import stoiridhtools.cli
+
+    if sys.version_info < (3, 5):
+        print('ERROR: Stòiridh Tools requires at least Python 3.5 to run.')
+        sys.exit(1)
+
+    if not (sys.platform.startswith('linux') or sys.platform.startswith('win32')):
+        print('ERROR: Stòiridh Tools is only available on GNU/Linux or Windows.')
+        sys.exit(1)
 
     # initialise Stòiridh Tools
     init()


### PR DESCRIPTION
There is no reason to allow the execution on platforms that are not supported.

Task-number: #65